### PR TITLE
add execution permission for directories created

### DIFF
--- a/strm.go
+++ b/strm.go
@@ -58,7 +58,7 @@ func (s *Strm) Save() error {
 
 // 生成Strm文件
 func (s *Strm) GenStrm(overwrite bool) error {
-	err := os.MkdirAll(s.LocalDir, 0666)
+	err := os.MkdirAll(s.LocalDir, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
使用时遇到类似
```
[2025-02-28 23:22:13] [warning] [MAIN]: generate file 成瘾剂量S01E08.strm failed: mkdir strm/成瘾剂量/Season 1: permission denied
```
的问题。此问题仅出现在路径中无需要下载的文件时。检查了一下发现
https://github.com/imshuai/AlistAutoStrm/blob/4c58020c261f599412f2fa25bb7ddfbb25759f1e/strm.go#L61
此处创建文件夹时未给予其 execute 权限，导致无法在文件夹下创建子文件夹或者文件，而
https://github.com/imshuai/AlistAutoStrm/blob/4c58020c261f599412f2fa25bb7ddfbb25759f1e/mission.go#L118
处就是用的是正确的权限，所以如果路径上下载过文件就不会触发上述问题。